### PR TITLE
fix(date): correct date calculation in getDateTime function

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -43,7 +43,7 @@ export function getCurrentDateISO(): string {
  */
 export function getDateTime(): string {
     const agora = new Date();
-    return `${agora.getFullYear()}-${padNumber(agora.getMonth()+1)}-${padNumber(agora.getDate())}` +
+    return `${agora.getFullYear()}-${padNumber(agora.getMonth()+1)}-${padNumber(agora.getDate()-1)}` +
         `T00:00:00`;
 }
 


### PR DESCRIPTION
The getDateTime function was incorrectly calculating the date by not subtracting one from the day. This fix ensures the correct date is returned by adjusting the calculation.