### PR TITLE
fix(xmlMoviments): update NUMEROMOV to use first 9 characters of NF n…

### DIFF
--- a/src/utils/xmlMoviments.ts
+++ b/src/utils/xmlMoviments.ts
@@ -2009,7 +2009,7 @@ export function xmlMovAPJ(campos: any, CODCOLIGADA: string, CODFILIAL: string, S
                     cData += XML.montaTag('CODLOC', ESTOQUE)
                     cData += XML.montaTag('CODLOCDESTINO', ESTOQUE)
                     cData += XML.montaTag('CODCFO', campos.codigoDoFornecedor)
-                    cData += XML.montaTag('NUMEROMOV', '-1')
+                    cData += XML.montaTag('NUMEROMOV', (campos.numeroDaNF).slice(0, 9))
                     cData += XML.montaTag('SERIE', 'ALPJ')
                     cData += XML.montaTag('CODTMV', CODTMV)
                     cData += XML.montaTag('TIPO', 'A')


### PR DESCRIPTION
…umber

Previously, NUMEROMOV was hardcoded to '-1', which could cause issues in processing. Now, it uses the first 9 characters of the NF number (campos.numeroDaNF) to ensure proper identification and avoid conflicts.