### PR TITLE
fix(xmlMoviments): replace dynamic CODCPG value with static '001'

### DIFF
--- a/src/utils/xmlMoviments.ts
+++ b/src/utils/xmlMoviments.ts
@@ -1134,7 +1134,7 @@ export function xmlMovRE(campos: any, CODCOLIGADA: string, CODFILIAL: string, SE
                     cData += XML.montaTag('FATIMPRESSA', '0')
                     cData += XML.montaTag('DATAEMISSAO', DATE.getDateTime())
                     cData += XML.montaTag('COMISSAOREPRES', '0.0000')
-                    cData += XML.montaTag('CODCPG', campos.codigoDaFormaPagamento)
+                    cData += XML.montaTag('CODCPG', '001')
                     cData += XML.montaTag('VALORBRUTO', campos.valorTotal)
                     cData += XML.montaTag('VALORLIQUIDO', campos.valorTotal)
                     cData += XML.montaTag('VALOROUTROS', campos.valorTotal)


### PR DESCRIPTION
The dynamic value for CODCPG was replaced with a static '001' to ensure consistency in the XML output. This change addresses potential issues with varying payment method codes.