### PR TITLE
fix: remove whitespace from chaveDeAcesso in xmlMovNM

### DIFF
--- a/src/utils/xmlMoviments.ts
+++ b/src/utils/xmlMoviments.ts
@@ -305,7 +305,7 @@ export function xmlMovNM(campos: any, CODCOLIGADA: string, CODFILIAL: string, SE
                     cData += XML.montaTag('FATIMPRESSA', '0')
                     cData += XML.montaTag('DATAEMISSAO', DATE.convertToISOFormat(campos.dataDeEmissao))
                     cData += XML.montaTag('COMISSAOREPRES', '0.0000')
-                    cData += XML.montaTag('CHAVEACESSONFE', campos.chaveDeAcesso)
+                    cData += XML.montaTag('CHAVEACESSONFE', campos.chaveDeAcesso.replace(/\s+/g, ''))
                     cData += XML.montaTag('CODCPG', campos.codigoDaFormaPagamento)
                     cData += XML.montaTag('VALORBRUTO', campos.valorTotal)
                     cData += XML.montaTag('VALORLIQUIDO', campos.valorTotal)


### PR DESCRIPTION
The chaveDeAcesso field in the XML generation was including whitespace, which could cause issues in downstream processing. This change ensures that all whitespace is removed from the field before it is added to the XML.